### PR TITLE
Fix CloudFront SSL certificate and error pages access issues

### DIFF
--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -133,6 +133,22 @@ data "aws_iam_policy_document" "cloudfront_ops_bucket_policy" {
       values   = [aws_cloudfront_distribution.website.arn]
     }
   }
+
+  statement {
+    sid    = "AllowCloudFrontLogging"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.cloudfront_ops.arn}/logs/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.website.arn]
+    }
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy


### PR DESCRIPTION
## Summary
This PR fixes CloudFront SSL certificate association and error pages access issues through three targeted commits.

## Changes Made
### 1. Add CloudFront domain aliases for SSL certificate association
- Fixes SSL certificate ERR_SSL_VERSION_OR_CIPHER_MISMATCH 
- Properly associates custom domain with ACM certificate

### 2. Add separate Origin Access Control for error pages
- Creates dedicated OAC for error pages origin
- Updates error pages origin to use new OAC
- Removes problematic origin_path causing double pathing

### 3. Add CloudFront logging permissions to S3 bucket policy
- Adds s3:PutObject permissions for CloudFront service
- Enables access logs to be written to /logs/* prefix

## Testing
- ✅ Custom domain SSL works: `https://kunduso.com`
- ✅ Error pages accessible: `https://kunduso.com/error-pages/404.html`
- ✅ Custom error responses trigger correctly for missing content
- ✅ CloudFront logging permissions configured

## Files Modified
- `infrastructure/cloudfront.tf` - Main CloudFront configuration updates

Closes #32