### PR TITLE
Fix CloudFront unable to serve content from KMS-encrypted S3 bucket

### DIFF
--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,3 +1,8 @@
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.website.id
+}
+
 output "cloudfront_domain" {
   description = "CloudFront distribution domain name"
   value       = aws_cloudfront_distribution.website.domain_name

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -65,6 +65,20 @@ data "aws_iam_policy_document" "s3_key_policy" {
       identifiers = ["s3.amazonaws.com"]
     }
   }
+
+  statement {
+    sid    = "Allow CloudFront to use the key"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    resources = [aws_kms_key.s3_key.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket


### PR DESCRIPTION
## Problem
Website returned 404 error page despite content existing in S3 bucket. Both custom domain (kunduso.com) and direct CloudFront domain returned 404.

## Root Cause
S3 bucket is encrypted with KMS (`aws:kms`), but the KMS key policy didn't grant CloudFront service permission to decrypt objects. CloudFront received 403 Forbidden from S3, which triggered the custom 404 error page.

## Changes
- Added CloudFront service principal to KMS key policy in `infrastructure/storage.tf`
- Grants `kms:Decrypt` and `kms:DescribeKey` permissions to `cloudfront.amazonaws.com`
- Removed circular dependency condition (`AWS:SourceArn`) for cleaner resource creation
- Added `cloudfront_distribution_id` to outputs.tf for convenience

## Verification
- ✅ Website now serves correct content at https://kunduso.com
- ✅ Direct CloudFront domain works: https://d11744ce0is90r.cloudfront.net
- ✅ Returns HTTP 200 with proper HTML content

Closes #35