### PR TITLE
Fix content pipeline to trigger on infrastructure and DNS changes

### DIFF
--- a/.github/workflows/deploy-content.yml
+++ b/.github/workflows/deploy-content.yml
@@ -5,11 +5,15 @@ on:
     branches: [ 'main' ]
     paths:
       - 'content/**'
+      - 'infrastructure/**'
+      - 'dns/**'
       - '.github/workflows/deploy-content.yml'
   pull_request:
     branches: [ 'main' ]
     paths:
       - 'content/**'
+      - 'infrastructure/**'
+      - 'dns/**'
       - '.github/workflows/deploy-content.yml'
 
 permissions: read-all


### PR DESCRIPTION
Closes #40

## Problem
The content deployment pipeline was only triggering on changes to  and the workflow file itself. This meant that when infrastructure or DNS changes were deployed, the content pipeline wouldn't run to sync content to the updated resources.

## Solution
Updated the  configuration in  to include:
-  - Ensures content deployment after infrastructure changes
-  - Ensures content deployment after DNS configuration changes

## Changes Made
- Added  to trigger paths
- Added  to trigger paths
- Applied to both  and  events

## Impact
Now when infrastructure changes are deployed (new S3 buckets, CloudFront distributions, etc.) or DNS configurations are updated, the content pipeline will automatically run to ensure content is properly synced to the updated resources.