### PR TITLE
Add DNSSEC DS record output to dns/outputs.tf

### DIFF
--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -7,3 +7,14 @@ output "hosted_zone_id" {
   description = "Route53 hosted zone ID"
   value       = aws_route53_zone.main.zone_id
 }
+
+# Output DS record
+output "ds_record" {
+  description = "Formatted DS record for registrar"
+  value = format("%s %s %s %s",
+    aws_route53_key_signing_key.main.key_tag,
+    aws_route53_key_signing_key.main.signing_algorithm_mnemonic,
+    aws_route53_key_signing_key.main.digest_algorithm_mnemonic,
+    aws_route53_key_signing_key.main.digest_value
+  )
+}


### PR DESCRIPTION
This PR adds the DS record output to the DNS stage so users can easily copy DNSSEC values from GitHub Actions logs to their domain registrar.

## Changes
- Added ds_record output from aws_route53_key_signing_key to dns/outputs.tf
- Users can now copy key tag, algorithm, digest type, and digest values directly from workflow logs
- Eliminates need to dig through Terraform state or AWS console

Closes #45